### PR TITLE
Redirect old links to search datasets

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -18,5 +18,11 @@ additional-js = ["mermaid.min.js", "mermaid-init.js"]
 git-repository-url = "https://github.com/mozilla/data-docs"
 google-analytics = "UA-104326577-1"
 
+[output.html.redirect]
+"/datasets/mozetl/search_aggregates/reference.html" = "/datasets/search/search_aggregates/reference.html"
+"/datasets/mozetl/search_clients_daily/reference.html" = "/datasets/search/search_clients_daily/reference.html"
+"/datasets/mozetl/search_clients_last_seen/reference.html" = "/datasets/search/search_clients_last_seen/reference.html"
+"/datasets/mozetl/client_ltv/reference.html" = "/datasets/search/client_ltv/reference.html"
+
 [preprocessor.open-on-gh]
 command = "mdbook-open-on-gh"


### PR DESCRIPTION
Uses the fairly-recently-added mdbook redirect feature for old links to the search datasets