### PR TITLE
Draft documentation for DS workflow for adding to clients_last_seen

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -43,6 +43,8 @@ Arkadiusz
 backend
 backends
 backfilled
+backfilling
+backfills
 behaviour
 Bhattacharyya
 BigQuery

--- a/src/cookbooks/clients_last_seen_bits.md
+++ b/src/cookbooks/clients_last_seen_bits.md
@@ -703,6 +703,9 @@ or joined with clients_daily for validations that involve slicing on dimensions.
 If the definition proves useful in validation, your variant of the query
 above can serve as a good starting point for Data Engineering to integrate the new
 definition into `clients_daily` (and `clients_last_seen` if necessary).
+Once a new definition is integrated into the model, we can backfill two months of
+data fairly easily. Complete backfills are expensive in terms of computational cost
+and engineering effort, so cannot happen more than approximately quarterly.
 
 ## UDF Reference
 

--- a/src/cookbooks/clients_last_seen_bits.md
+++ b/src/cookbooks/clients_last_seen_bits.md
@@ -627,16 +627,15 @@ The operational logic required to produce a `clients_last_seen` table makes
 it unwieldy for backfilling, so it has historically been difficult for data
 scientists to experiment with new bit pattern fields on their own.
 
-Below is a sample query for producing a small `clients_last_seen`-like view
+Below are sample queries for producing a small `clients_last_seen`-like table
 that presents an experimental usage definition. In this approach, the temporary
 analysis table we create actually stores a client's whole usage history as a
 BYTES field, and then we rely on view logic to present this as per-day windows.
 Much of the logic is boilerplate; the sections that would need to change for
 your specific new field are marked between `-- BEGIN` and `-- END` comments.
 
-The example queries `main_v4` directly in order to be as generic as possible.
-The `daily` CTE below could be removed in the case that `clients_daily` already
-provides a daily measure that can be used as basis for your new bit pattern feature.
+The first example defines a new feature based on a measure that already exists
+in `clients_daily`. It takes only a few minutes to run:
 
 ```sql
 DECLARE start_date DATE DEFAULT '2020-05-01';
@@ -704,6 +703,8 @@ CROSS JOIN
 WHERE
   (days_active_bits >> i) IS NOT NULL
 ```
+
+And here is a more complex example that references `main_v4` directly:
 
 <details>
 <summary>Calculating a bit pattern field directly from `main_v4`</summary>

--- a/src/cookbooks/clients_last_seen_bits.md
+++ b/src/cookbooks/clients_last_seen_bits.md
@@ -705,7 +705,9 @@ WHERE
   (days_active_bits >> i) IS NOT NULL
 ```
 
-<details><summary>Calculating a bit pattern field directly from `main_v4`</summary>
+<details>
+<summary>Calculating a bit pattern field directly from `main_v4`</summary>
+
 ```sql
 DECLARE start_date DATE DEFAULT '2020-05-01';
 DECLARE end_date DATE DEFAULT '2020-11-01';
@@ -792,6 +794,7 @@ CROSS JOIN
 WHERE
   (days_active_bits >> i) IS NOT NULL
 ```
+
 </details>
 
 This script takes about 10 minutes to run over 6 months of data as written above

--- a/src/cookbooks/clients_last_seen_bits.md
+++ b/src/cookbooks/clients_last_seen_bits.md
@@ -667,6 +667,9 @@ PARTITION BY submission_date
 CLUSTER BY sample_id
 AS
 WITH
+-- If clients_daily already contains a measure that suffices as the basis for
+-- our new usage definition, we can skip this daily subquery and calculate
+-- alltime based on clients_daily rather than `main`.
 daily AS (
   SELECT
     DATE(submission_timestamp) AS submission_date,
@@ -724,6 +727,8 @@ WHERE
 
 This script takes about 10 minutes to run over 6 months of data as written above
 and about an hour to run over the whole history of `main_v4` (starting at 2018-11-01).
+A query over the whole history of `clients_daily` (starting in early 2016)
+can run in about an hour as well.
 The resultant table can be used on its own
 or joined with `clients_daily` to pull per-client dimensions.
 


### PR DESCRIPTION
I will be shopping around this workflow to some Data Scientists for review. It is intended to empower them to explore new feature usage definitions in a manner that has a clear path to being included in clients_last_seen if it proves useful.

I'm coming to the conclusion that [a general `clients_all_time` or `feature_usage_all_time` table](https://docs.google.com/document/d/1pWDgOB3rvfvuwB71EKqvSJJCHpX8iGCU9bS9yVGV31w/edit#) is not feasible in the short term, but the technique is still useful for rapid prototyping of bit patterns that can be used to investigate new user segmentation, feature usage definitions, etc.

Relevant to the [Data Warehouse daily aggregations sub-project](https://docs.google.com/document/d/1Lml-hWiqhvUazjn_-sDF6TUvwAEA3jMG3LJbyIC7fEc/edit#).