### PR TITLE
Remove databricks links and change docs

### DIFF
--- a/src/concepts/engagement.md
+++ b/src/concepts/engagement.md
@@ -94,8 +94,3 @@ other than HTTP and HTTPS. It excludes some (but not all) `about:` pages
 e.g. `about:config` and `about:telemetry` are included.
 
 No applications of `unfiltered_uri_count` have been identified.
-
-1.  Ping `reason` for `main` pings [observed][db_notebook]
-    from Firefox 65 `release` channel users on February 21, 2019.
-
-[db_notebook]: https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/82297/revision/1554433978453

--- a/src/concepts/glean/glean.md
+++ b/src/concepts/glean/glean.md
@@ -79,7 +79,6 @@ This includes previously manual and error-prone steps such as updating the ping 
   - There is [more documentation about accessing Glean data](accessing_glean_data.md).
 
 - _(Work in progress)_ Use events and [Amplitude](https://sso.mozilla.com/amplitude) for product analytics.
-- [Use Databricks](https://sso.mozilla.com/databricks) for deep-dive analysis.
 - For experimentation, you can use [Android experiments library](https://github.com/mozilla-mobile/android-components/blob/master/components/service/experiments/README.md), which integrates with Glean.
 
 # Contact

--- a/src/concepts/pipeline/data_pipeline.md
+++ b/src/concepts/pipeline/data_pipeline.md
@@ -96,7 +96,7 @@ The deployment scripts and configuration files of the CEP & DWL live in a [priva
 
 # Spark
 
-Once the data reaches our data lake on S3 it can be processed with Spark on Mozilla's [Databricks instance]. Databricks allows Mozilla employees to write custom analyses in notebooks, and also schedule Databricks jobs to run periodically.
+Once the data reaches our data lake on S3 it can be processed with Spark on Mozilla's Databricks instance. Databricks allows Mozilla employees to write custom analyses in notebooks, and also schedule Databricks jobs to run periodically.
 
 As mentioned earlier, most of our data lake contains data serialized to Protobuf with free-form JSON fields. Needless to say, parsing JSON is terribly slow when ingesting Terabytes of data per day. A set of [ETL jobs], written in Scala by Data Engineers and scheduled with [Airflow], create [Parquet views] of our raw data. We have a Github repository [telemetry-batch-view] that showcases this.
 
@@ -207,4 +207,3 @@ There is a vast ecosystem of tools for processing data at scale, each with their
 [redash]: https://redash.io/
 [stmo]: https://sql.telemetry.mozilla.org/
 [fork of redash]: https://github.com/mozilla/redash
-[databricks instance]: https://dbc-caf9527b-e073.cloud.databricks.com

--- a/src/concepts/pipeline/data_pipeline_detail.md
+++ b/src/concepts/pipeline/data_pipeline_detail.md
@@ -237,7 +237,7 @@ There is a command-line interface to STMO called [St. Mocli], if you prefer writ
 
 ##### Databricks: Managed Spark Analysis
 
-Our [Databricks instance] (see [Databricks docs]) offers another notebook interface for doing analysis in Scala, SQL, Python and R.
+Our Databricks instance (see [Databricks docs]) offers another notebook interface for doing analysis in Scala, SQL, Python and R.
 
 Databricks provides an always-on shared server which is nice for quick data investigations.
 
@@ -383,7 +383,6 @@ graph LR
 [stmo]: ../../tools/stmo.md
 [jupyter]: https://jupyter.org/
 [zeppelin]: https://zeppelin.apache.org/
-[databricks instance]: https://dbc-caf9527b-e073.cloud.databricks.com
 [databricks docs]: https://docs.databricks.com/user-guide/notebooks/index.html
 [tmo]: https://telemetry.mozilla.org
 [measurement dashboard]: https://telemetry.mozilla.org/new-pipeline/dist.html

--- a/src/datasets/bigquery/exact_mau/reference.md
+++ b/src/datasets/bigquery/exact_mau/reference.md
@@ -137,9 +137,7 @@ ORDER BY
 Additional usage criteria may be added in the future as new columns named
 `*_*mau`, etc. where the prefix describes the usage criterion.
 
-For convenience and clarity, we make the exact data presented in the
-[2019 Key Performance Indicator Dashboard](https://dbc-caf9527b-e073.cloud.databricks.com/#job/1160/run/latestSuccess/dashboard/42765b23-7b69-4d59-b08b-ea9cf45b63df)
-available as views that do not require any aggregation:
+For convenience and clarity, we make the exact data presented in the 2019 Key Performance Indicator Dashboard available as views that do not require any aggregation:
 
 - `firefox_desktop_exact_mau28_v1`,
 - `firefox_nondesktop_exact_mau28_v1`, and

--- a/src/datasets/bigquery/exact_mau/reference.md
+++ b/src/datasets/bigquery/exact_mau/reference.md
@@ -137,7 +137,7 @@ ORDER BY
 Additional usage criteria may be added in the future as new columns named
 `*_*mau`, etc. where the prefix describes the usage criterion.
 
-For convenience and clarity, we make the exact data presented in the 2019 Key Performance Indicator Dashboard available as views that do not require any aggregation:
+For convenience and clarity, we make the exact data presented in the [Key Performance Indicator Dashboard](https://go.corp.mozilla.com/kpi-dash) available as views that do not require any aggregation:
 
 - `firefox_desktop_exact_mau28_v1`,
 - `firefox_nondesktop_exact_mau28_v1`, and

--- a/src/datasets/search/search_clients_daily/intro.md
+++ b/src/datasets/search/search_clients_daily/intro.md
@@ -32,7 +32,6 @@ We impute a `NULL` `engine` and `source` for pings with no search counts.
 This ensures users who never search are included in this dataset.
 
 This dataset is large.
-Consider using Spark on [Databricks](https://dbc-caf9527b-e073.cloud.databricks.com).
 If you're querying this dataset from STMO,
 heavily limit the data you read using `submission_date` or `sample_id`.
 

--- a/src/tools/guiding_principles.md
+++ b/src/tools/guiding_principles.md
@@ -32,7 +32,7 @@ transforming data (ETL) once it's in BigQuery.
 
 Once data is accessible through BigQuery, users within Mozilla also get the
 benefit of leveraging common tools for data access. Beyond the Google-provided
-BigQuery console, Mozilla provides access to instances of Redash, Databricks,
+BigQuery console, Mozilla provides access to instances of Redash,
 Tableau, and other tools either with connections to BigQuery already available
 or with concrete instructions for provisioning connections.
 

--- a/src/tools/interfaces.md
+++ b/src/tools/interfaces.md
@@ -34,10 +34,3 @@ is an instance of the very fine [Redash](https://redash.io/) software, allowing
 for SQL-based exploratory analysis and visualization / dashboard
 construction. Requires (surprise!) familiarity with SQL, and for your data to
 be explicitly exposed as an STMO data source. You can learn more about how to use it in [Introduction to STMO](./stmo.md). Bugs or feature requests can be reported in Mozilla's [issue tracker](https://github.com/mozilla/redash/issues).
-
-### Databricks
-
-> **⚠** Databricks will be available until the end of 2020.
-
-[Databricks](https://dbc-caf9527b-e073.cloud.databricks.com/) offers a notebook interface with shared, always-on, autoscaling cluster (attaching your notebooks to `shared_serverless_python3` is the best way to start).
-Convenient for quick data investigations. Users are advised to join the [`databricks-discuss@mozilla.com`](https://groups.google.com/a/mozilla.com/forum/#!forum/databricks-discuss) group.

--- a/src/tools/spark.md
+++ b/src/tools/spark.md
@@ -12,7 +12,7 @@ Here are some useful introductory materials:
 - [Spark Programming Guide](https://spark.apache.org/docs/latest/programming-guide.html)
 - [Spark SQL Programming Guide](https://spark.apache.org/docs/latest/sql-programming-guide.html)
 
-Spark can be used either from [Databricks Notebooks](https://docs.databricks.com/notebooks/index.html) or [Google's Dataproc](https://cloud.google.com/dataproc/), and works with data stored in BigQuery.
+Spark can be used from [Google's Dataproc](https://cloud.google.com/dataproc/), and works with data stored in BigQuery.
 
 There are a number of methods of both reading from and writing to BigQuery using Spark.
 
@@ -24,20 +24,11 @@ There are a number of methods of both reading from and writing to BigQuery using
 
 If you want to use Spark locally (or via an arbitrary GCP instance in the cloud), we recommend the [Storage API Connector](https://github.com/GoogleCloudPlatform/spark-bigquery-connector) for accessing BigQuery tables in Spark as it is the most modern and actively developed connector. It works well with the BigQuery client library which is useful if you need to run arbitrary SQL queries and load their results into Spark.
 
-### Using Databricks
-
-> **⚠** Databricks will be available until the end of 2020.
-
-[Databricks Notebooks](https://docs.databricks.com/notebooks/index.html) provide an interactive
-computational environment, similar to Jupyter. If you are a Mozilla employee, you should be able to access it via [`sso.mozilla.com/databricks`](https://sso.mozilla.com/databricks).
-
-The `shared_serverless_python3` cluster is configured with shared default GCP credentials, so you can immediately use the BigQuery client libraries.
-
 ### Using Dataproc
 
 > **⚠** This method requires [BigQuery Access](../cookbooks/bigquery/access.md#bigquery-access-request) to be provisioned.
 
-Dataproc is Google's managed Spark cluster service. Accessing BigQuery from there will be faster than from Databricks because it does not involve cross-cloud data transfers.
+Dataproc is Google's managed Spark cluster service. Accessing BigQuery from there will be fast because it does not involve cross-cloud data transfers.
 
 You can spin up a Dataproc cluster with Jupyter using the following command. Insert your values for `cluster-name`, `bucket-name`, and `project-id` there. Your notebooks are stored in Cloud Storage under `gs://bucket-name/notebooks/jupyter`:
 
@@ -72,6 +63,8 @@ There are two main ways to read data from BigQuery into Spark: using either the 
 query API.
 
 ### Storage API
+
+> **⚠** Databricks is shut down as of January 2021. The storage API will not work on Google Dataproc.
 
 First, using the Storage API - this bypasses BigQuery's execution engine and
 directly reads from the underlying storage.
@@ -118,8 +111,6 @@ core_pings_single_day = spark.read.format("bigquery") \
     .where("submission_timestamp >= to_date('2019-08-25') submission_timestamp < to_date('2019-08-26')") \
     .select("client_id", "experiments", "normalized_channel")
 ```
-
-You can see this code in action in [this example Python notebook on Databricks](https://dbc-caf9527b-e073.cloud.databricks.com/#notebook/141939).
 
 A couple of things are worth noting in the above example.
 

--- a/src/tools/spark.md
+++ b/src/tools/spark.md
@@ -28,7 +28,7 @@ If you want to use Spark locally (or via an arbitrary GCP instance in the cloud)
 
 > **⚠** This method requires [BigQuery Access](../cookbooks/bigquery/access.md#bigquery-access-request) to be provisioned.
 
-Dataproc is Google's managed Spark cluster service. Accessing BigQuery from there will be fast because it does not involve cross-cloud data transfers.
+Dataproc is Google's managed Spark cluster service.
 
 You can spin up a Dataproc cluster with Jupyter using the following command. Insert your values for `cluster-name`, `bucket-name`, and `project-id` there. Your notebooks are stored in Cloud Storage under `gs://bucket-name/notebooks/jupyter`:
 
@@ -64,7 +64,6 @@ query API.
 
 ### Storage API
 
-> **⚠** Databricks is shut down as of January 2021. The storage API will not work on Google Dataproc.
 
 First, using the Storage API - this bypasses BigQuery's execution engine and
 directly reads from the underlying storage.


### PR DESCRIPTION
Where possible this removes mentioning of Databricks as one way to do things.
It is kept in historical docs for ... history.
All links to Mozilla's Databricks have been removed as the instance is shut down.