### PR TITLE
Bug 1689427 - Add a schema deploys FAQ with information about blocked schemas

### DIFF
--- a/src/concepts/pipeline/schemas.md
+++ b/src/concepts/pipeline/schemas.md
@@ -60,26 +60,26 @@ This section answers some basic questions about the schema deployment pipeline.
 ### How do I make changes to a schema?
 
 This is dependent on what application you are working on. If you are working on Firefox Telemetry or
-custom ping, you will often want to make changes to [mozilla-pipeline-schemas][mps]. If you are
+custom ping, you will often want to make changes to [`mozilla-pipeline-schemas`][mps]. If you are
 adding a new probe, then you don't have to do anything. Changes are automatically picked up by the
-[probe-scraper][probe-scraper] from the `histograms.json` and `scalars.yaml` files in
+[`probe-scraper`][probe-scraper] from the `histograms.json` and `scalars.yaml` files in
 mozilla-central. If you are working on Glean, then the probe-scraper will automatically pick up
 changes from the `metrics.yaml`.
 
 ### When will I see new changes to the schema?
 
 Schema deploys occur daily around UTC+04 when new changes are found in the
-[mozilla-schema-generator][msg]. See the [mozilla-pipeline-schemas deploy][mps-deploys] dashboard
-for up-to-date information on the most recent deploys.
+[`mozilla-schema-generator`][msg]. See the [`mozilla-pipeline-schemas` deploy][mps-deploys]
+dashboard for up-to-date information on the most recent deploys.
 
 ### What does it mean when a schema deploy is blocked?
 
-The schema deployment pipeline has a hard dependency on the [probe-scraper], a service that scours
+The schema deployment pipeline has a hard dependency on the [`probe-scraper`], a service that scours
 repositories for new metrics to include in generated schemas. When the probe-scraper fails, it will
-prevent the [mozilla-schema-generator][msg] from running. If there are new changes to the main
-branch of mozilla-pipeline-schemas, then they will not be added to the generated-schemas branch
+prevent the [`mozilla-schema-generator`][msg] from running. If there are new changes to the main
+branch of `mozilla-pipeline-schemas`, then they will not be added to the `generated-schemas` branch
 until the failure has been resolved. Similarly, new probes and pings in either Telemetry or Glean
-will not be picked up until the probe-scraper failures are resolved.
+will not be picked up until the `probe-scraper` failures are resolved.
 
 If a new schema field is not registered in the schema repository before collection begins, it will
 be available in the `additional_properties` field of the generated table. If a new schema for a ping

--- a/src/concepts/pipeline/schemas.md
+++ b/src/concepts/pipeline/schemas.md
@@ -7,7 +7,8 @@
 Schemas describe the structure of ingested data. They are used in the pipeline to validate the types
 and values of data, and to define a table schema in a data store. We use a repository of JSON
 Schemas to sort incoming data into [`decoded` and `error` datasets][bq-datasets]. We also generate
-BigQuery table schemas nightly from the JSON Schemas: you can see the current status of this job on the [`mozilla-pipeline-schemas` deploy dashboard][mps-deploys].
+BigQuery table schemas on business days from the JSON Schemas: you can see the current status of
+this job on the [`mozilla-pipeline-schemas` deploy dashboard][mps-deploys].
 
 ```mermaid
 graph TD
@@ -60,15 +61,22 @@ This section answers some basic questions about the schema deployment pipeline.
 
 This is dependent on what application you are working on.
 
-If you are working on Firefox Telemetry and are adding a new probe, then you don't have to do anything. Changes are automatically picked up by the [`probe-scraper`][probe-scraper] from the `histograms.json` and `scalars.yaml` files in `mozilla-central`. Non-probe changes (for example, modifications to the telemetry environment) will require you to make changes to [`mozilla-pipeline-schemas`][mps].
+If you are working on Firefox Telemetry and are adding a new probe, then you don't have to do
+anything. Changes are automatically picked up by the [`probe-scraper`][probe-scraper] from the
+`histograms.json` and `scalars.yaml` files in `mozilla-central`. Non-probe changes (for example,
+modifications to the telemetry environment) will require you to make changes to
+[`mozilla-pipeline-schemas`][mps].
 
-If you are working on an application using the [Glean SDK](../glean/glean.md), then the probe-scraper will automatically pick up changes from `metrics.yaml`.
+If you are working on an application using the [Glean SDK](../glean/glean.md), then the
+probe-scraper will automatically pick up changes from `metrics.yaml`.
 
 ### When will I see new changes to the schema?
 
-Schema deploys occur daily around UTC+04 when new changes are found in the
-[`generated-schemas branch of mozilla-pipeline-schemas`][https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas]. This means that any changes merged after UTC+04 on Friday will not propagate until Monday UTC+04. See the [`mozilla-pipeline-schemas` deploy][mps-deploys]
-dashboard for up-to-date information on the most recent deploys.
+Schema deploys happen on business days around UTC+04 when new changes are found in the
+[`generated-schemas` branch of `mozilla-pipeline-schemas`][generated-schemas]. This means that any
+changes merged after UTC+04 on Friday will not propagate until Monday UTC+04. See the
+[`mozilla-pipeline-schemas` deploy][mps-deploys] dashboard for up-to-date information on the most
+recent deploys.
 
 ### What does it mean when a schema deploy is blocked?
 
@@ -82,12 +90,13 @@ will not be picked up until the `probe-scraper` failures are resolved.
 If a new schema field is not registered in the schema repository before collection begins, it will
 be available in the `additional_properties` field of the generated table. If a new schema for a ping
 is not registered before collection begins, then it will be sorted into the error stream. Please
-[file a bug](../reporting_a_problem.md) or [reach out](../getting_help.md) if you believe your data may be affected by blocked schema
-deploys.
+[file a bug](../reporting_a_problem.md) or [reach out](../getting_help.md) if you believe your data
+may be affected by blocked schema deploys.
 
 [bq-datasets]: ../../cookbooks/bigquery/querying.md#projects-with-bigquery-datasets
 [mps-deploys]: https://protosaur.dev/mps-deploys/
 [mps]: https://github.com/mozilla-services/mozilla-pipeline-schemas
+[generated-schemas]: https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schema
 [msg]: https://github.com/mozilla/mozilla-schema-generator
 [probe-scraper]: https://github.com/mozilla/probe-scraper
 

--- a/src/concepts/pipeline/schemas.md
+++ b/src/concepts/pipeline/schemas.md
@@ -7,8 +7,7 @@
 Schemas describe the structure of ingested data. They are used in the pipeline to validate the types
 and values of data, and to define a table schema in a data store. We use a repository of JSON
 Schemas to sort incoming data into [`decoded` and `error` datasets][bq-datasets]. We also generate
-BigQuery table schemas nightly from the JSON Schemas. You may also be also interested in the
-[`mozilla-pipeline-schemas` deploy dashboard][mps-deploys].
+BigQuery table schemas nightly from the JSON Schemas: you can see the current status of this job on the [`mozilla-pipeline-schemas` deploy dashboard][mps-deploys].
 
 ```mermaid
 graph TD
@@ -59,17 +58,16 @@ This section answers some basic questions about the schema deployment pipeline.
 
 ### How do I make changes to a schema?
 
-This is dependent on what application you are working on. If you are working on Firefox Telemetry or
-custom ping, you will often want to make changes to [`mozilla-pipeline-schemas`][mps]. If you are
-adding a new probe, then you don't have to do anything. Changes are automatically picked up by the
-[`probe-scraper`][probe-scraper] from the `histograms.json` and `scalars.yaml` files in
-`mozilla-central`. If you are working on Glean, then the probe-scraper will automatically pick up
-changes from the `metrics.yaml`.
+This is dependent on what application you are working on.
+
+If you are working on Firefox Telemetry and are adding a new probe, then you don't have to do anything. Changes are automatically picked up by the [`probe-scraper`][probe-scraper] from the `histograms.json` and `scalars.yaml` files in `mozilla-central`. Non-probe changes (for example, modifications to the telemetry environment) will require you to make changes to [`mozilla-pipeline-schemas`][mps].
+
+If you are working on an application using the [Glean SDK](../glean/glean.md), then the probe-scraper will automatically pick up changes from `metrics.yaml`.
 
 ### When will I see new changes to the schema?
 
 Schema deploys occur daily around UTC+04 when new changes are found in the
-[`mozilla-schema-generator`][msg]. See the [`mozilla-pipeline-schemas` deploy][mps-deploys]
+[`generated-schemas branch of mozilla-pipeline-schemas`][https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas]. This means that any changes merged after UTC+04 on Friday will not propagate until Monday UTC+04. See the [`mozilla-pipeline-schemas` deploy][mps-deploys]
 dashboard for up-to-date information on the most recent deploys.
 
 ### What does it mean when a schema deploy is blocked?
@@ -84,7 +82,7 @@ will not be picked up until the `probe-scraper` failures are resolved.
 If a new schema field is not registered in the schema repository before collection begins, it will
 be available in the `additional_properties` field of the generated table. If a new schema for a ping
 is not registered before collection begins, then it will be sorted into the error stream. Please
-file a bug or reach out in #data-help if you believe your data may be affected by blocked schema
+[file a bug](../reporting_a_problem.md) or [reach out](../getting_help.md) if you believe your data may be affected by blocked schema
 deploys.
 
 [bq-datasets]: ../../cookbooks/bigquery/querying.md#projects-with-bigquery-datasets

--- a/src/concepts/pipeline/schemas.md
+++ b/src/concepts/pipeline/schemas.md
@@ -8,7 +8,7 @@ Schemas describe the structure of ingested data. They are used in the pipeline t
 and values of data, and to define a table schema in a data store. We use a repository of JSON
 Schemas to sort incoming data into [`decoded` and `error` datasets][bq-datasets]. We also generate
 BigQuery table schemas nightly from the JSON Schemas. You may also be also interested in the
-[mozilla-pipeline-schemas deploy dashboard][mps-deploys].
+[`mozilla-pipeline-schemas` deploy dashboard][mps-deploys].
 
 ```mermaid
 graph TD
@@ -63,7 +63,7 @@ This is dependent on what application you are working on. If you are working on 
 custom ping, you will often want to make changes to [`mozilla-pipeline-schemas`][mps]. If you are
 adding a new probe, then you don't have to do anything. Changes are automatically picked up by the
 [`probe-scraper`][probe-scraper] from the `histograms.json` and `scalars.yaml` files in
-mozilla-central. If you are working on Glean, then the probe-scraper will automatically pick up
+`mozilla-central`. If you are working on Glean, then the probe-scraper will automatically pick up
 changes from the `metrics.yaml`.
 
 ### When will I see new changes to the schema?


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1689427)

This adds a small FAQ to the schemas documentation page. It is the first entry when searching for "schema deploy". This should cover most of the end-user concerns around blocked schemas.