### PR TITLE
Add a note about GLAM access being limited

### DIFF
--- a/src/cookbooks/glam.md
+++ b/src/cookbooks/glam.md
@@ -4,6 +4,8 @@ GLAM was built to help Mozillians answer their data questions without needing da
 
 GLAM is one of several high-level data tools that we provide at Mozilla. For more information, see [Tools for Data Analysis](../tools/interfaces.md).
 
+Access to GLAM is currently limited to Mozilla employees and designated contributors (this [may change in the future](https://bugzilla.mozilla.org/show_bug.cgi?id=1712353)). For more information, see [gaining access](../concepts/gaining_access.md).
+
 ## How to use GLAM
 
 You can visit GLAM at [`glam.telemetry.mozilla.org`](https://glam.telemetry.mozilla.org). As of this writing, Mozilla LDAP credentials are required to access it.

--- a/src/cookbooks/glam.md
+++ b/src/cookbooks/glam.md
@@ -8,7 +8,7 @@ Access to GLAM is currently limited to Mozilla employees and designated contribu
 
 ## How to use GLAM
 
-You can visit GLAM at [`glam.telemetry.mozilla.org`](https://glam.telemetry.mozilla.org). As of this writing, Mozilla LDAP credentials are required to access it.
+You can visit GLAM at [`glam.telemetry.mozilla.org`](https://glam.telemetry.mozilla.org).
 
 ### Front page
 


### PR DESCRIPTION
Currently GLAM access is limited to people with LDAP access, this might change in the future but let's
at least make this clear. Link to a bug I just filed so people can track the current status.