### PR TITLE
Add 404 analysis gotcha

### DIFF
--- a/.linkcheck.json
+++ b/.linkcheck.json
@@ -13,6 +13,7 @@
         { "pattern": "^https://monitor.firefox.com$" },
         { "pattern": "^https://developer.android.com/studio/build/application-id$" },
         { "pattern": "^https://github.com" },
-        { "pattern": "^https://help.looker.com"}
+        { "pattern": "^https://help.looker.com"},
+        { "pattern": "^https://mozilla-hub.atlassian.net" }
     ]
 }

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,6 +24,7 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
+- **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].
 - **Nov 4, 2021** - [CORS headers added to support receiving submissions from Glean.js websites][bug1676676].
 - **Sep 30 2021 - Oct 06 2021** - [Submissions from some countries were rejected][bug1733953].
 - **Sep 30 2021 - Oct 04 2021** - [Submissions from clients on some older platforms were dropped][bug1733953].
@@ -83,6 +84,7 @@ When you start to evaluate trends, be aware of events from the past that may inv
 [bug1729069]: https://bugzilla.mozilla.org/show_bug.cgi?id=1729069
 [bug1733953]: https://bugzilla.mozilla.org/show_bug.cgi?id=1733953
 [bug1676676]: https://bugzilla.mozilla.org/show_bug.cgi?id=1676676
+[jirads1843]: https://mozilla-hub.atlassian.net/browse/DS-1843
 
 ## Pseudo-replication
 


### PR DESCRIPTION
There are some SRE incident docs but they might be private. We didn't create an internal issue for this except the DS ticket to analyze impact so I've linked to that. We could perhaps alternatively link to https://status.cloud.google.com/incidents/6PM5mNd43NbMqjCZ5REh directly.