### PR TITLE
Expand the SSL dataset docs' example

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -359,6 +359,7 @@ unicode
 unmanaged
 unnest
 unnesting
+unnormalize
 unnormalized
 Unnormalized
 unsuffixed


### PR DESCRIPTION
The example was mathematically correct but gave a false impression of how to use the dataset.
Can't forget to unnormalize the result, or you'll get weird figures.
Also, emphasize that the normalization is per-`submission_date`.