### PR TITLE
add suggest link

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -116,6 +116,7 @@
     - [bmobugs](datasets/other/bmobugs/reference.md)
     - [Build metadata](datasets/buildhub.md)
     - [Release information](datasets/releases.md)
+    - [Suggest](datasets/other/suggest/suggest.md)
   - [Firefox Accounts Datasets](datasets/fxa.md)
     - [Firefox Account Attribution](datasets/fxa_metrics/attribution.md)
     - [Firefox Account Funnel Metrics](datasets/fxa_metrics/funnels.md)


### PR DESCRIPTION
need to add link to new article in SUMMARY.md according to [Adding a new article](https://docs.telemetry.mozilla.org/contributing/index.html#adding-a-new-article), that's probably why it's not shown in DTMO yet :)

