### PR TITLE
add an item for anlaysis_gotchas section

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -111,6 +111,7 @@ Dockerfile
 dropdown
 DSRE
 DTMO
+DuckDuckGo
 DWL
 DXR
 DynamoDB

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,7 +24,7 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
-- **May 15 2022** - [Fixed potential under report `search_with_ads`][bug1673868].
+- **May 15 2022** - [Fixed potential under report `search_with_ads`][bug 1673868].
   Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo.
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,7 +24,7 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
-- **May 15 2022** - [Fixed under-reporting of `search with ads`][bug1673868].
+- **May 15 2022** - [Fixed potential under reporting of `search with ads`][bug1673868].
   Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo.
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,6 +24,8 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
+- **May 15 2022** - [Fixed under-reporting of search with ads][bug1673868]
+  Ad impressions were not tracked for SERPs that took longer than 1 second to load. This was initially uncovered by QA for the DuckDuckGo SERP's ad impressions. The fix addresses all search partner's and is not limited to DuckDuckGo. 
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].
 - **Nov 4, 2021** - [CORS headers added to support receiving submissions from Glean.js websites][bug1676676].

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,7 +24,7 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
-- **May 15 2022** - [Fixed potential under reporting of `search with ads`][bug1673868].
+- **May 15 2022** - [Fixed potential under report `search_with_ads`][bug1673868].
   Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo.
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,8 +24,8 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
-- **May 15 2022** - [Fixed under-reporting of `search with ads`][bug1673868]
-  Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo. 
+- **May 15 2022** - [Fixed under-reporting of `search with ads`][bug1673868].
+  Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo.
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].
 - **Nov 4, 2021** - [CORS headers added to support receiving submissions from Glean.js websites][bug1676676].

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -24,8 +24,8 @@ Especially severe problems with production data are announced on the `fx-data-de
 
 When you start to evaluate trends, be aware of events from the past that may invite comparisons with history. Here are a few to keep in mind:
 
-- **May 15 2022** - [Fixed under-reporting of search with ads][bug1673868]
-  Ad impressions were not tracked for SERPs that took longer than 1 second to load. This was initially uncovered by QA for the DuckDuckGo SERP's ad impressions. The fix addresses all search partner's and is not limited to DuckDuckGo. 
+- **May 15 2022** - [Fixed under-reporting of `search with ads`][bug1673868]
+  Ad impressions were not tracked for SERP that took longer than 1 second to load. This was initially uncovered by QA for ad impressions on DuckDuckGo SERP. The fix addresses for all search partners and is not limited to DuckDuckGo. 
 - **Dec 1 2021 - Jan 23 2022** - [Search values in Android Focus from core telemetry fell][jirado673].
 - **Nov 16, 2021** - [Submissions were rejected from 17:44 to 18:10 UTC][jirads1843].
 - **Nov 4, 2021** - [CORS headers added to support receiving submissions from Glean.js websites][bug1676676].


### PR DESCRIPTION
add an item for anlaysis_gotchas section basically fixed under-reporting of search with ads. Details in https://bugzilla.mozilla.org/show_bug.cgi?id=1673868 and https://mozilla-hub.atlassian.net/browse/SNT-88