### PR TITLE
Helps clarify example in sql guidelines

### DIFF
--- a/src/concepts/sql_style.md
+++ b/src/concepts/sql_style.md
@@ -240,20 +240,20 @@ Do not include multiple arguments on one line.
 ```sql
 SELECT client_id, submission_date
 FROM main_summary
-WHERE
-  submission_date > '20180101'
+WHERE submission_date > '20180101'
   AND sample_id = '42'
 LIMIT 10
 ```
 
-**Bad**
+**Good**
 
 ```sql
 SELECT
   client_id,
   submission_date
 FROM main_summary
-WHERE submission_date > '20180101'
+WHERE
+  submission_date > '20180101'
   AND sample_id = '42'
 LIMIT 10
 ```


### PR DESCRIPTION
The example for `Do not include multiple arguments on one line` has a second bad example that may confuse the reader. 

The reason is it fixes a problem the bad example has but also introduces a new problem the bad example didn't have. This change would move both issues into the first bad example and fix them both in the good example.