### PR TITLE
Fix typo in `monzanalysis` example

### DIFF
--- a/src/concepts/metric_hub.md
+++ b/src/concepts/metric_hub.md
@@ -226,7 +226,7 @@ To use the metrics with Mozanalysis, you'll need `Metric`s not `MetricDefinition
 
 ```python
 from mozanalysis.config import ConfigLoader
-metric = ConfigLoader.get_metric(slug="active_hours", app_name="firefox_desktop")
+metric = ConfigLoader.get_metric(metric_slug="active_hours", app_name="firefox_desktop")
 ```
 
 ## FAQ


### PR DESCRIPTION
[`ConfigLoader.get_metric` requires a `metric_slug` argument, not a `slug` argument](https://github.com/mozilla/mozanalysis/blob/cb118046359c3945b459465bbb63ce64bf7460b3/src/mozanalysis/config.py#L30)