### PR TITLE
Update SQL style guide about indenting join conditions

### DIFF
--- a/src/concepts/sql_style.md
+++ b/src/concepts/sql_style.md
@@ -260,7 +260,7 @@ LIMIT 10
 
 ## Join Conditions
 
-The `ON` or `USING` keyword should start on a new line indented one level more than the join keyword
+The `ON` and `USING` keywords should start on a new line indented one level more than the join keyword
 and be followed by the join conditions starting on the same line. For example:
 
 **Good**:

--- a/src/concepts/sql_style.md
+++ b/src/concepts/sql_style.md
@@ -258,6 +258,44 @@ WHERE submission_date > '20180101'
 LIMIT 10
 ```
 
+## Join Conditions
+
+The `ON` or `USING` keyword should start on a new line indented one level more than the join keyword
+and be followed by the join conditions starting on the same line. For example:
+
+**Good**:
+
+```sql
+...
+FROM
+  telemetry_stable.main_v4
+LEFT JOIN
+  static.normalized_os_name
+  ON main_v4.environment.system.os.name = normalized_os_name.os_name
+```
+
+**Bad**:
+
+```sql
+...
+FROM
+  telemetry_stable.main_v4
+LEFT JOIN
+  static.normalized_os_name ON main_v4.environment.system.os.name = normalized_os_name.os_name
+```
+
+**Bad**:
+
+```sql
+...
+FROM
+  telemetry_stable.main_v4
+LEFT JOIN
+  static.normalized_os_name
+ON
+  main_v4.environment.system.os.name = normalized_os_name.os_name
+```
+
 ## Parentheses
 
 If parentheses span multiple lines:

--- a/src/cookbooks/retention.md
+++ b/src/cookbooks/retention.md
@@ -88,8 +88,7 @@ FROM
   `moz-fx-data-shared-prod.telemetry.desktop_retention_1_week`
 RIGHT JOIN
   my_cohort_t
-USING
-  (client_id)
+  USING (client_id)
 WHERE
   date BETWEEN "2020-03-01" AND "2020-03-07"
 GROUP BY

--- a/src/datasets/static/normalized_os.md
+++ b/src/datasets/static/normalized_os.md
@@ -22,8 +22,7 @@ FROM
   telemetry_stable.main_v4
 LEFT JOIN
   static.normalized_os_name
-ON
-  (environment.system.os.name = os_name)
+  ON (environment.system.os.name = os_name)
 ```
 
 ### OS Versions


### PR DESCRIPTION
mozilla/bigquery-etl#4223 is changing `bqetl format` to indent join conditions.