### PR TITLE
Update connecting_external_data_bigquery.md

### DIFF
--- a/src/cookbooks/operational/connecting_external_data_bigquery.md
+++ b/src/cookbooks/operational/connecting_external_data_bigquery.md
@@ -20,7 +20,7 @@ description: >
 owners:
   - example@mozilla.com
 external_data:
-  format: google_sheet
+  format: google_sheets
   source_uris:
     - https://docs.google.com/spreadsheets/d/Avakdiasl341kdasdf # URL to the spreadsheet
   options:


### PR DESCRIPTION
Without the `s` we get: ValueError: 'google_sheet' is not a valid ExternalDataFormat