### PR TITLE
Add Jira Epic link and issues log to documentation

### DIFF
--- a/src/cookbooks/data_monitoring/intro.md
+++ b/src/cookbooks/data_monitoring/intro.md
@@ -10,3 +10,10 @@ If you do not have the necessary access or permissions, please [submit a Jira ti
 ## Getting Started
 
 Watch the [Bigeye tutorial](https://www.youtube.com/watch?v=8DWyZuU-w1c&t=9s) to get an overview of the platform.
+Please refer to additional helpful videos available on the Bigeye channel.
+
+## Stay Updated on What's Happening
+[Jira Epic Link](https://mozilla-hub.atlassian.net/browse/DENG-4563)
+
+## Have an issue or looking for a new feature in Bigeye
+If you're experiencing any issues while using the issues tracker for [Bigeye](https://docs.google.com/spreadsheets/d/1L7JrbgTaVsKKFIK3ilKKttUfuzHh91xSeBFC0VZTp68)

--- a/src/cookbooks/data_monitoring/issues_management.md
+++ b/src/cookbooks/data_monitoring/issues_management.md
@@ -42,5 +42,3 @@ The Bigeye integration with Jira enables teams to track critical data quality is
 
 Bigeye enables users to take direct actions on issues on Slack messages without needing to navigate to the Bigeye web interface.
 Users can resolve, mute, or dismiss alerts directly from Slack messages, ensuring efficient workflows and quick responses to data quality issues.
-
-## Recommendation / Best practices [Coming Soon]


### PR DESCRIPTION
I added the Jira Epic, Issues tracker, and instruction to refer to Bigeye Youtube channel. 